### PR TITLE
Get runtime asset name dynamically

### DIFF
--- a/merge-runtime.js
+++ b/merge-runtime.js
@@ -1,5 +1,10 @@
 const ConcatSource = require("webpack-sources/lib/ConcatSource");
 
+function getAssetName(chunks, name) {
+  const foundChunk = chunks.find(chunk => chunk.name === name)
+  return foundChunk.files[0]
+}
+
 module.exports = class ModuleFedSingleRuntimePlugin {
   constructor(options) {
     this._options = { fileName: "remoteEntry.js", ...options };
@@ -13,8 +18,10 @@ module.exports = class ModuleFedSingleRuntimePlugin {
     compiler.hooks.emit.tap(
       "EnableSingleRunTimeForFederationPlugin",
       (compilation) => {
-        const { assets } = compilation;
-        const runtime = assets["runtime.js"];
+        const { assets, chunks, options } = compilation;
+        const runtimeChunkName = options.optimization.runtimeChunk.name()
+        const runtimeAssetName = getAssetName(chunks, runtimeChunkName)
+        const runtime = assets[runtimeAssetName];
         const remoteEntry = assets[this._options.fileName];
         const mergedSource = new ConcatSource(runtime, remoteEntry);
         assets[this._options.fileName] = mergedSource;


### PR DESCRIPTION
Runtime asset name is hard-coded in the plugin code as `runtime.js`. It works for case with `optimization.runtimeChunk: "single"` and default values in `output.filename`.

The name of a runtime chunk could be specified with
```JS
optimization: {
  runtimeChunk: {
    name: "mainfest"
  }
}
```
So the runtime asset name would be `manifest.js`. See webpack [docs](https://webpack.js.org/configuration/optimization/#optimizationruntimechunk).

The other case is when the `optimization.runtimeChunk: "single"`, but a value of `output.filename` contains any hash, e.g. 
```JS
optimization: {
  runtimeChunk: "single"
},
output: {
  filename: "[name].[chunkhash].js"
}
```
So the runtime asset name would be `runtime.0cf4cbd4e57ce970.js` (used random hash here). See webpack [docs](https://webpack.js.org/configuration/output/#outputfilename)

To fix the first case we need to get a runtime chunk name from a given webpack configuration passed in `compilation.options`. There is a `optimization.runtimeChunk.name` property which has a function value. Calling the function returns a name of a runtime chunk. A name of runtime asset is the same as a name of runtime chunk in this case.

To fix the second case we need to get a runtime asset name from a given runtime chunk object. Having a runtime chunk name we can find runtime chunk object in `compilation.chunk` by name. An asset name is a value in first element of `chunk.files` array.